### PR TITLE
Migrate from `name.full()` to `name_full()` to future-proof editing a user into an organization

### DIFF
--- a/docassemble/VacateDefaultForeclosure/data/questions/vacate_default_foreclosure.yml
+++ b/docassemble/VacateDefaultForeclosure/data/questions/vacate_default_foreclosure.yml
@@ -689,11 +689,11 @@ subquestion: |
 ---
 id: user agree
 question: |
-  Does ${users[i].name.full(middle='full')} want to sign the motion with you?
+  Does ${users[i].name_full()} want to sign the motion with you?
 subquestion: | 
-  You should only click **Yes** if ${users[i].name.full(middle='full')} fully agrees with you and the reasons you want to delay the foreclosure sale.
+  You should only click **Yes** if ${users[i].name_full()} fully agrees with you and the reasons you want to delay the foreclosure sale.
 
-  If ${users[i].name.full(middle='full')} has any other responses or different reasons they want to delay the foreclosure sale, click **No**.
+  If ${users[i].name_full()} has any other responses or different reasons they want to delay the foreclosure sale, click **No**.
 fields:
   - no label: users[i].agree
     datatype: yesnoradio
@@ -701,16 +701,16 @@ fields:
 id: about user signatures
 continue button field: users[i].need_signature
 question: |
-  ${users[i].name.full(middle='full')} needs to sign
+  ${users[i].name_full()} needs to sign
 subquestion: |
-  ${users[i].name.full(middle='full')} will need to sign the forms before they can be filed.
+  ${users[i].name_full()} will need to sign the forms before they can be filed.
 ---
 id: need to send
 continue button field: users[i].need_to_send
 question: |
-  Giving a copy to ${users[i].name.full(middle='full')}
+  Giving a copy to ${users[i].name_full()}
 subquestion: |
-  You will need to provide a copy of your forms to ${users[i].name.full(middle='full')}.
+  You will need to provide a copy of your forms to ${users[i].name_full()}.
   
   More instructions on how to do this will be provided later.
 ---
@@ -722,11 +722,11 @@ sets:
 generic object: ALIndividual
 question: |
   % if showifdef("users[i].agree"):
-  What is ${ users[i].name.full(middle="full") }'s address?
+  What is ${ users[i].name_full() }'s address?
   % elif users[i].is_represented:
-  What is ${ users[i].lawyer.name.full(middle="full") }'s address?
+  What is ${ users[i].lawyer.name_full() }'s address?
   % else:
-  What is ${ users[i].name.full(middle="full") }'s address?
+  What is ${ users[i].name_full() }'s address?
   % endif
 fields:
   - Street address: users[i].address.address
@@ -824,7 +824,7 @@ subquestion: |
 generic object: ALIndividual
 id: has lawyer
 question: |
-  Does ${ x.name.full(middle="full") } have a lawyer in this case?
+  Does ${ x.name_full() } have a lawyer in this case?
 field: x.is_represented
 choices:
   - Yes: True
@@ -835,7 +835,7 @@ choices:
 id: add lawyer
 generic object: ALIndividual
 question: |
-  Who is  ${ x.name.full(middle="full") }'s lawyer?
+  Who is  ${ x.name_full() }'s lawyer?
 fields:
   - First name: x.lawyer.name.first
   - Middle name: x.lawyer.name.middle
@@ -854,11 +854,11 @@ sets:
 generic object: ALIndividual
 question: |
   % if showifdef("x.agree"):
-  What is ${ x.name.full(middle="full") }'s address?
+  What is ${ x.name_full() }'s address?
   % elif x.is_represented:
-  What is ${ x.lawyer.name.full(middle="full") }'s address?
+  What is ${ x.lawyer.name_full() }'s address?
   % else:
-  What is ${ x.name.full(middle="full") }'s address?
+  What is ${ x.name_full() }'s address?
   % endif
 fields:
   - Street address: x.address.address
@@ -876,9 +876,9 @@ id: knows delivery method
 generic object: ALIndividual
 question: |
   % if x.is_represented:
-  Do you know **how** and **when** you will send your forms to ${ x.lawyer.name.full(middle="full") }?
+  Do you know **how** and **when** you will send your forms to ${ x.lawyer.name_full() }?
   % else:
-  Do you know **how** and **when** you will send your forms to ${ x.name.full(middle="full") }?
+  Do you know **how** and **when** you will send your forms to ${ x.name_full() }?
   % endif
 subquestion: |
   ${ collapse_template(delivery_method_help) }  
@@ -915,9 +915,9 @@ generic object: ALIndividual
 id: party delivery method
 question: |
   % if x.is_represented:
-  How will you send your forms to ${ x.lawyer.name.full(middle="full") }?
+  How will you send your forms to ${ x.lawyer.name_full() }?
   % else:
-  How will you send your forms to ${ x.name.full(middle="full") }?
+  How will you send your forms to ${ x.name_full() }?
   % endif
 subquestion: |  
   If the other party listed an email address on the court documents, you must send the forms to them by email or through the e-filing system. You may use US mail or a delivery company, or hand delivery if you or the other party **does not** have an email address. If you are in a prison or jail, you can deliver by mail.
@@ -1031,9 +1031,9 @@ id: delivery time
 generic object: ALIndividual
 question: |
   % if x.is_represented:
-  When will you send your forms to ${ x.lawyer.name.full(middle="full") }?
+  When will you send your forms to ${ x.lawyer.name_full() }?
   % else:
-  When will you send your forms to ${ x.name.full(middle="full") }?
+  When will you send your forms to ${ x.name_full() }?
   % endif
 subquestion: |
   For best results, complete the Proof of Delivery section and send the forms today.
@@ -1074,7 +1074,7 @@ subquestion: |
 ---
 id: other user phone
 question: |
-  What is ${users[i].name.full(middle='full')}'s phone number?
+  What is ${users[i].name_full()}'s phone number?
 subquestion: |
   If you do not know this, you can leave this blank.
 fields:  
@@ -1114,7 +1114,7 @@ id: user e-signature
 question: |
   Do you want to add your e-signature to your forms?
 subquestion: |
-  This program can put “**/s/ ${users[0].name.full(middle='full')}**” where you would sign your name. The court will accept this as your signature.
+  This program can put “**/s/ ${users[0].name_full()}**” where you would sign your name. The court will accept this as your signature.
 
   If you do not add your **{e-signature}**, you must sign your paper forms before you file and deliver them.
 
@@ -1264,12 +1264,12 @@ attachment:
     - "no_extra_time": ${True if present_at_hearing and order_reasons['time'] else False}
     - "at_hearing_other_check": ${True if present_at_hearing and order_reasons['other'] else False}
     - "at_hearing_other_text": ${at_other_reason if present_at_hearing and order_reasons['other'] else ""}
-    - "defendant_name_1": ${users[0].name.full(middle='full')}
-    - "defendant_signature_1": ${users[0].name.full(middle='full') if e_signature else ""}
+    - "defendant_name_1": ${users[0].name_full()}
+    - "defendant_signature_1": ${users[0].name_full() if e_signature else ""}
     - "defendant_street_1": ${users[0].address.line_one(bare=True)}
     - "defendant_csz_1": ${users[0].address.line_two()}
     - "defendant_phone_1": ${phone_number_formatted(users[0].phone_number)}
-    - "defendant_name_2": ${signing_users[1].name.full(middle='full')}
+    - "defendant_name_2": ${signing_users[1].name_full()}
     - "defendant_signature_2": ${""}
     - "defendant_street_2": ${signing_users[1].address.line_one(bare=True)}
 ---
@@ -1285,7 +1285,7 @@ attachment:
     - "case_number_4": ${ case_number }
     - "defendant_csz_2": ${signing_users[1].address.line_two()}
     - "defendant_phone_2": ${phone_number_formatted(signing_users[1].phone_number)}
-    - "defendant_name_3": ${signing_users[2].name.full(middle='full')}
+    - "defendant_name_3": ${signing_users[2].name_full()}
     - "defendant_signature_3": ${""}
     - "defendant_street_3": ${signing_users[2].address.line_one(bare=True)}
     - "defendant_csz_3": ${signing_users[2].address.line_two()}
@@ -1305,9 +1305,9 @@ attachment:
     - "additional_signatures": ${True if signing_users.number_gathered() > 3 else False}
     - "delivery_party_name_1": |
         % if delivery_parties[0].is_represented:
-        ${delivery_parties[0].lawyer.name.full(middle='full')} (lawyer for ${delivery_parties[0].name.full(middle='full')})
+        ${delivery_parties[0].lawyer.name_full()} (lawyer for ${delivery_parties[0].name_full()})
         % else:
-        ${delivery_parties[0].name.full(middle='full')}
+        ${delivery_parties[0].name_full()}
         % endif
     - "delivery_party_address_1": ${delivery_parties[0].address.on_one_line(bare=True)}
     - "delivery_email_1": ${delivery_parties[0].delivery_email}
@@ -1374,9 +1374,9 @@ attachment:
     - "delivery_pm_1": ${True if format_time(delivery_parties[0].delivery_time, format='a') == "PM" and delivery_parties[0].knows_delivery_method else False}
     - "delivery_party_name_2": |
         % if delivery_parties[1].is_represented:
-        ${delivery_parties[1].lawyer.name.full(middle='full')} (lawyer for ${delivery_parties[1].name.full(middle='full')})
+        ${delivery_parties[1].lawyer.name_full()} (lawyer for ${delivery_parties[1].name_full()})
         % else:
-        ${delivery_parties[1].name.full(middle='full')}
+        ${delivery_parties[1].name_full()}
         % endif
     - "delivery_party_address_2": ${delivery_parties[1].address.on_one_line(bare=True)}
     - "delivery_email_2": ${delivery_parties[1].delivery_email}
@@ -1443,9 +1443,9 @@ attachment:
     - "delivery_pm_2": ${True if format_time(delivery_parties[1].delivery_time, format='a') == "PM" and delivery_parties[1].knows_delivery_method else False}
     - "delivery_party_name_3": |
         % if delivery_parties[2].is_represented:
-        ${delivery_parties[2].lawyer.name.full(middle='full')} (lawyer for ${delivery_parties[2].name.full(middle='full')})
+        ${delivery_parties[2].lawyer.name_full()} (lawyer for ${delivery_parties[2].name_full()})
         % else:
-        ${delivery_parties[2].name.full(middle='full')}
+        ${delivery_parties[2].name_full()}
         % endif
     - "delivery_party_address_3": ${delivery_parties[2].address.on_one_line(bare=True)}
     - "delivery_email_3": ${delivery_parties[2].delivery_email}
@@ -1522,8 +1522,8 @@ attachment:
   fields:
     - "case_number_5": ${ case_number } 
     - "user_street": ${users[0].address.line_one(bare=True)}
-    - "user_signature": ${users[0].name.full(middle='full') if e_signature else ""}
-    - "user_name": ${users[0].name.full(middle='full')}
+    - "user_signature": ${users[0].name_full() if e_signature else ""}
+    - "user_name": ${users[0].name_full()}
     - "user_csz": ${users[0].address.line_two()}
     - "user_phone": ${phone_number_formatted(users[0].phone_number)}
 ---
@@ -1547,15 +1547,15 @@ attachment:
     - "hearing_am": ${False}
     - "hearing_pm": ${False}
     - "user_street": ${users[0].address.line_one(bare=True)}
-    - "user_signature": ${users[0].name.full(middle='full') if e_signature else ""}
-    - "user_name": ${users[0].name.full(middle='full')}
+    - "user_signature": ${users[0].name_full() if e_signature else ""}
+    - "user_name": ${users[0].name_full()}
     - "user_csz": ${users[0].address.line_two()}
     - "user_phone": ${phone_number_formatted(users[0].phone_number)}
     - "delivery_party_name_1": |
         % if delivery_parties[0].is_represented:
-        ${delivery_parties[0].lawyer.name.full(middle='full')} (lawyer for ${delivery_parties[0].name.full(middle='full')})
+        ${delivery_parties[0].lawyer.name_full()} (lawyer for ${delivery_parties[0].name_full()})
         % else:
-        ${delivery_parties[0].name.full(middle='full')}
+        ${delivery_parties[0].name_full()}
         % endif
     - "delivery_party_address_1": ${delivery_parties[0].address.on_one_line(bare=True)}
     - "delivery_email_1": ${delivery_parties[0].delivery_email}
@@ -1622,9 +1622,9 @@ attachment:
     - "delivery_pm_1": ${True if format_time(delivery_parties[0].delivery_time, format='a') == "PM" and delivery_parties[0].knows_delivery_method else False}
     - "delivery_party_name_2": |
         % if delivery_parties[1].is_represented:
-        ${delivery_parties[1].lawyer.name.full(middle='full')} (lawyer for ${delivery_parties[1].name.full(middle='full')})
+        ${delivery_parties[1].lawyer.name_full()} (lawyer for ${delivery_parties[1].name_full()})
         % else:
-        ${delivery_parties[1].name.full(middle='full')}
+        ${delivery_parties[1].name_full()}
         % endif
     - "delivery_party_address_2": ${delivery_parties[1].address.on_one_line(bare=True)}
     - "delivery_email_2": ${delivery_parties[1].delivery_email}
@@ -1691,9 +1691,9 @@ attachment:
     - "delivery_pm_2": ${True if format_time(delivery_parties[1].delivery_time, format='a') == "PM" and delivery_parties[1].knows_delivery_method else False}
     - "delivery_party_name_3": |
         % if delivery_parties[2].is_represented:
-        ${delivery_parties[2].lawyer.name.full(middle='full')} (lawyer for ${delivery_parties[2].name.full(middle='full')})
+        ${delivery_parties[2].lawyer.name_full()} (lawyer for ${delivery_parties[2].name_full()})
         % else:
-        ${delivery_parties[2].name.full(middle='full')}
+        ${delivery_parties[2].name_full()}
         % endif
     - "delivery_party_address_3": ${delivery_parties[2].address.on_one_line(bare=True)}
     - "delivery_email_3": ${delivery_parties[2].delivery_email}
@@ -1785,9 +1785,9 @@ attachment:
     - "case_number": ${case_number}
     - "delivery_party_name_4": |
         % if x.is_represented:
-        ${x.lawyer.name.full(middle='full')} (lawyer for ${x.name.full(middle='full')})
+        ${x.lawyer.name_full()} (lawyer for ${x.name_full()})
         % else:
-        ${x.name.full(middle='full')}
+        ${x.name_full()}
         % endif
     - "delivery_party_address_4": ${x.address.on_one_line(bare=True)}
     - "delivery_party_email_4": |
@@ -1883,9 +1883,9 @@ attachment:
     - "two_on_sheet": ${x.include_two}
     - "delivery_party_name_5": |
         % if x.second_person.is_represented:
-        ${x.second_person.lawyer.name.full(middle='full')} (lawyer for ${x.second_person.name.full(middle='full')})
+        ${x.second_person.lawyer.name_full()} (lawyer for ${x.second_person.name_full()})
         % else:
-        ${x.second_person.name.full(middle='full')}
+        ${x.second_person.name_full()}
         % endif
     - "delivery_party_address_5": ${x.second_person.address.on_one_line(bare=True)}
     - "delivery_party_email_5": |
@@ -1977,9 +1977,9 @@ attachment:
     - "prison_name_5": ${x.second_person.delivery_jail_name}
     - "delivery_date_5": ${x.second_person.delivery_date if x.second_person.knows_delivery_method else ""}
     - "delivery_time_5": ${format_time(x.second_person.delivery_time, format='h:mm a') if x.second_person.knows_delivery_method and x.second_person.delivery_time != "" else ""}
-    - "user_signature": ${users[0].name.full(middle='full') if e_signature else ""}
+    - "user_signature": ${users[0].name_full() if e_signature else ""}
     - "user_address": ${users[0].address.on_one_line(bare=True)}
-    - "user_name": ${users[0].name.full(middle='full')}
+    - "user_name": ${users[0].name_full()}
     - "user_phone": ${phone_number_formatted(users[0].phone_number) if users[0].phone_number != "" else ""}
     - "user_email": ${users[0].email if users[0].has_email_address else ""}
 ---
@@ -1998,21 +1998,21 @@ attachment:
     - "defendant_names": |
         ${users.full_names()}
     - "case_number": ${case_number}
-    - "codefendant_name_1": ${x.name.full(middle='full')}
+    - "codefendant_name_1": ${x.name_full()}
     - "codefendant_street_1": ${x.address.line_one(bare=True)}
     - "codefendant_csz_1": ${x.address.line_two()}
     - "codefendant_phone_1": ${phone_number_formatted(x.phone_number) if x.phone_number != "" else ""}
-    - "codefendant_name_2": ${x.second_person.name.full(middle='full')}
+    - "codefendant_name_2": ${x.second_person.name_full()}
     - "codefendant_street_2": ${x.second_person.address.line_one(bare=True)}
     - "codefendant_csz_2": ${x.second_person.address.line_two()}
     - "codefendant_phone_2": ${phone_number_formatted(x.second_person.phone_number) if x.second_person.phone_number != "" else ""}
-    - "codefendant_name_3": ${x.third_person.name.full(middle='full')}
+    - "codefendant_name_3": ${x.third_person.name_full()}
     - "codefendant_street_3": ${x.third_person.address.line_one(bare=True)}
     - "codefendant_csz_3": ${x.third_person.address.line_two()}
     - "codefendant_phone_3": ${phone_number_formatted(x.third_person.phone_number) if x.phone_number != "" else ""}
-    - "signature_1": ${"/s/ " + x.name.full(middle='full') if x.party_signs else ""}
-    - "signature_2": ${"/s/ " + x.second_person.name.full(middle='full') if x.second_person.party_signs else ""}
-    - "signature_3": ${"/s/ " + x.third_person.name.full(middle='full') if x.third_person.party_signs else ""}
+    - "signature_1": ${"/s/ " + x.name_full() if x.party_signs else ""}
+    - "signature_2": ${"/s/ " + x.second_person.name_full() if x.second_person.party_signs else ""}
+    - "signature_3": ${"/s/ " + x.third_person.name_full() if x.third_person.party_signs else ""}
 ---
 reconsider: True
 code: |
@@ -2121,14 +2121,14 @@ review:
       **Defendants: (Edit to change name, address, and other info)**
       
       % for my_var in users:
-        * ${ my_var.name.full(middle="full") }
+        * ${ my_var.name_full() }
       % endfor
   - Edit: other_parties.revisit
     button: |
       **Plaintiffs: (Edit to change name, address, and delivery info)**
 
       % for my_var in other_parties:
-        * ${ my_var.name.full(middle="full") }
+        * ${ my_var.name_full() }
       % endfor
   - Edit: 
       - trial_court_index
@@ -2160,7 +2160,7 @@ table: users.table
 rows: users
 columns:
   - Name: |
-      row_item.name.full(middle="full") if defined("row_item.name.first") else ""
+      row_item.name_full() if defined("row_item.name.first") else ""
   - Address, phone number, and other info: |
       action_button_html(url_action(row_item.attr_name("review_user")), label="Edit", icon="pencil-alt")
 delete buttons: True
@@ -2180,7 +2180,7 @@ table: other_parties.table
 rows: other_parties
 columns:
   - Name: |
-      row_item.name.full(middle="full") if defined("row_item.name.first") else ""
+      row_item.name_full() if defined("row_item.name.first") else ""
   - Address, lawyer, and delivery info: |
       action_button_html(url_action(row_item.attr_name("review_other_delivery")), label="Edit", icon="pencil-alt")
 delete buttons: True
@@ -2191,7 +2191,7 @@ continue button field: x.review_user
 section: Case info
 generic object: ALIndividual
 question: |
-  Edit ${ x.name.full(middle="full") }'s information
+  Edit ${ x.name_full() }'s information
 subquestion: |  
   % if x != users[0]:
   If you don't see lawyer, address, or delivery information, then it might not be entered yet. Continue the program to answer all the questions.
@@ -2200,13 +2200,13 @@ review:
   - Edit: x.name.first
     button: |
       **Party name:**
-      ${ x.name.full(middle="full")  }
+      ${ x.name_full()  }
   - Edit: x.address.address
     button: |
       % if x == users[0]:
       **Your address:**
       % else:
-      **${ x.name.full(middle="full")  }'s address:**
+      **${ x.name_full()  }'s address:**
       % endif
       ${x.address.on_one_line(bare=True)}
   - Edit: x.phone_number
@@ -2214,7 +2214,7 @@ review:
       % if x == users[0]:
       **Your phone number:**
       % else:
-      **${ x.name.full(middle="full")  }'s phone number:**
+      **${ x.name_full()  }'s phone number:**
       % endif
       ${ phone_number_formatted(x.phone_number) }
   - Edit: x.has_email_address
@@ -2229,11 +2229,11 @@ review:
     show if: x == users[0] and x.has_email_address
   - Edit: x.agree
     button: |
-      **Does ${x.name.full(middle='full')} fully agree with your motion?**
+      **Does ${x.name_full()} fully agree with your motion?**
       ${word(yesno(x.agree))}
   - Edit: x.is_represented
     button: |
-      **Does ${ x.name.full(middle="full") } have a lawyer?**
+      **Does ${ x.name_full() } have a lawyer?**
       % if x.is_represented is None:
       I don't know
       % else:
@@ -2243,14 +2243,14 @@ review:
   - Edit: x.lawyer.name.first
     button: |
       **Lawyer name:**
-      ${ x.lawyer.name.full(middle="full") }
+      ${ x.lawyer.name_full() }
     show if: x.is_represented and not x.agree
   - Edit: x.address.address
     button: |
       % if x.is_represented == True:
-      **${ x.lawyer.name.full(middle="full") }'s address:**
+      **${ x.lawyer.name_full() }'s address:**
       % else:
-      **${ x.name.full(middle="full") }'s address:**
+      **${ x.name_full() }'s address:**
       % endif
       ${ x.address.on_one_line(bare=True) }
     show if: not x.agree
@@ -2297,17 +2297,17 @@ continue button field: x.review_other_delivery
 section: Delivery details
 generic object: ALIndividual
 question: |
-  Edit ${ x.name.full(middle="full") }'s information
+  Edit ${ x.name_full() }'s information
 subquestion: |  
   If you don't see lawyer, address, or delivery information, then it might not be entered yet. Continue the program to answer all the questions.
 review: 
   - Edit: x.name.first
     button: |
       **Party name:**
-      ${ x.name.full(middle="full")  }
+      ${ x.name_full()  }
   - Edit: x.is_represented
     button: |
-      **Does ${ x.name.full(middle="full") } have a lawyer?**
+      **Does ${ x.name_full() } have a lawyer?**
       % if x.is_represented is None:
       I don't know
       % else:
@@ -2316,14 +2316,14 @@ review:
   - Edit: x.lawyer.name.first
     button: |
       **Lawyer name:**
-      ${ x.lawyer.name.full(middle="full") }
+      ${ x.lawyer.name_full() }
     show if: x.is_represented
   - Edit: x.address.address
     button: |
       % if x.is_represented == True:
-      **${ x.lawyer.name.full(middle="full") }'s address:**
+      **${ x.lawyer.name_full() }'s address:**
       % else:
-      **${ x.name.full(middle="full") }'s address:**
+      **${ x.name_full() }'s address:**
       % endif
       ${ x.address.on_one_line(bare=True) }
   - Edit: x.knows_delivery_method
@@ -2442,7 +2442,7 @@ review:
       **Defendants: (Edit to change name, address, and other info)**
       
       % for my_var in users:
-        * ${ my_var.name.full(middle="full") }
+        * ${ my_var.name_full() }
       % endfor
 ---
 id: delivery filing review screen
@@ -2458,14 +2458,14 @@ review:
       **Defendants: (Edit to change name, address, and other info)**
       
       % for my_var in users:
-        * ${ my_var.name.full(middle="full") }
+        * ${ my_var.name_full() }
       % endfor
   - Edit: other_parties.revisit
     button: |
       **Plaintiffs: (Edit to change name, address, and delivery info)**
 
       % for my_var in other_parties:
-        * ${ my_var.name.full(middle="full") }
+        * ${ my_var.name_full() }
       % endfor
   - Edit: users[0].has_email_address
     button: |
@@ -2527,14 +2527,14 @@ review:
       **Defendants: (Edit to change name, address, and other info)**
       
       % for my_var in users:
-        * ${ my_var.name.full(middle="full") }
+        * ${ my_var.name_full() }
       % endfor
   - Edit: other_parties.revisit
     button: |
       **Plaintiffs: (Edit to change name, address, and delivery info)**
 
       % for my_var in other_parties:
-        * ${ my_var.name.full(middle="full") }
+        * ${ my_var.name_full() }
       % endfor
   - Edit: 
       - trial_court_index


### PR DESCRIPTION

Previously, it was possible to have leftover text in the .name.last field which would not be removed
if the user used a review screen and changed the person type from Individual to Business.

This PR replaces any use of `.name.full(middle="full")` with `name_full()`, which in a future
version of the AssemblyLine framework will solve this problem by not printing the last name
when the `person_type` is "business"

## How this change was made

This change was made by searching for any repos that had the text `name.full(middle="full") using gh-search,
and then the text was replaced with turbolift --sed as follows:

```bash
turbolift foreach -- bash -lc '
  # 1) enable ** to recurse
  shopt -s globstar

  # 2) for each .yml, replace both " and '\'' variants
  for f in **/*.yml; do
    sed -i "s/name\.full(middle=\"full\")/name_full()/g" "$f"
    sed -i "s/name\.full(middle='\''full'\'')/name_full()/g" "$f"
  done
'
```

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>